### PR TITLE
#37 jcabi-ajc.log moved to target

### DIFF
--- a/src/it/ajc/verify.groovy
+++ b/src/it/ajc/verify.groovy
@@ -30,3 +30,5 @@
 
 def file = new File(basedir, 'target/jcabi-ajc/com/jcabi/foo/Sample.class')
 assert file.exists()
+assert !new File(basedir, 'target/classes/jcabi-ajc.log').exists()
+assert new File(basedir, 'target/jcabi-ajc.log').exists()

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -184,7 +184,7 @@ public final class AjcMojo extends AbstractMojo implements Contextualizable {
         required = false,
         readonly = false,
         property = "log",
-        defaultValue = "${project.build.outputDirectory}/jcabi-ajc.log"
+        defaultValue = "${project.build.directory}/jcabi-ajc.log"
     )
     private transient String log;
 


### PR DESCRIPTION
#37 
* updated invoker test to check that jcabi-ajc.log is created in target and not in target/classes
* changed `project.build.outputDirectory` (`target/classes`) to `project.build.directory` (`target`)