### PR TITLE
 #41 Use Classpath provided by Maven Core for AJC command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,17 +79,6 @@
             <artifactId>jcabi-maven-slf4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.maven.shared</groupId>
-            <artifactId>maven-dependency-tree</artifactId>
-            <version>2.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>junit</groupId>
-                    <artifactId>junit</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
@@ -156,18 +145,6 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>${maven.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-            <version>1.5.5</version>
-            <scope>compile</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.collections</groupId>
-                    <artifactId>google-collections</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.sonatype.sisu</groupId>


### PR DESCRIPTION
  - Configure the ajc Mojo with "requiresDependencyResolution = ResolutionScope.COMPILE"
  - Add classpathElements field as @Parameter with ${project.compileClasspathElements} default value
  - Remove all unnecessary code previously used to generate classpath