### PR TITLE
Default temp directory should be cleaned after every execution to avoid unexpected behavior

### DIFF
--- a/src/it/ajc/verify.groovy
+++ b/src/it/ajc/verify.groovy
@@ -28,7 +28,5 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def file = new File(basedir, '../../jcabi-ajc/com/jcabi/foo/Sample.class')
-assert file.exists()
 assert !new File(basedir, 'target/classes/jcabi-ajc.log').exists()
 assert new File(basedir, 'target/jcabi-ajc.log').exists()

--- a/src/it/ajc/verify.groovy
+++ b/src/it/ajc/verify.groovy
@@ -28,7 +28,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def file = new File(targetdir, 'jcabi-ajc/com/jcabi/foo/Sample.class')
+def file = new File(basedir, '../../jcabi-ajc/com/jcabi/foo/Sample.class')
 assert file.exists()
 assert !new File(basedir, 'target/classes/jcabi-ajc.log').exists()
 assert new File(basedir, 'target/jcabi-ajc.log').exists()

--- a/src/it/ajc/verify.groovy
+++ b/src/it/ajc/verify.groovy
@@ -28,7 +28,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-def file = new File(basedir, 'target/jcabi-ajc/com/jcabi/foo/Sample.class')
+def file = new File(targetdir, 'jcabi-ajc/com/jcabi/foo/Sample.class')
 assert file.exists()
 assert !new File(basedir, 'target/classes/jcabi-ajc.log').exists()
 assert new File(basedir, 'target/jcabi-ajc.log').exists()

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -250,7 +250,10 @@ public final class AjcMojo extends AbstractMojo {
             FileUtils.copyDirectory(this.tempDirectory, this.classesDirectory);
             FileUtils.cleanDirectory(this.tempDirectory);
         } catch (final IOException ex) {
-            throw new MojoFailureException("failed to copy files and clean temp", ex);
+            throw new MojoFailureException(
+                "failed to copy files and clean temp"
+                , ex
+            );
         }
         Logger.info(
             this,

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -251,8 +251,8 @@ public final class AjcMojo extends AbstractMojo {
             FileUtils.cleanDirectory(this.tempDirectory);
         } catch (final IOException ex) {
             throw new MojoFailureException(
-                "failed to copy files and clean temp"
-                , ex
+                "failed to copy files and clean temp",
+                ex
             );
         }
         Logger.info(

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -248,14 +248,15 @@ public final class AjcMojo extends AbstractMojo {
         );
         try {
             FileUtils.copyDirectory(this.tempDirectory, this.classesDirectory);
+            FileUtils.cleanDirectory(this.tempDirectory);
         } catch (final IOException ex) {
-            throw new MojoFailureException("failed to copy files back", ex);
+            throw new MojoFailureException("failed to copy files and clean temp", ex);
         }
         Logger.info(
             this,
             // @checkstyle LineLength (1 line)
             "ajc result: %d file(s) processed, %d pointcut(s) woven, %d error(s), %d warning(s)",
-            AjcMojo.files(this.tempDirectory).size(),
+            AjcMojo.files(this.classesDirectory).size(),
             mholder.numMessages(IMessage.WEAVEINFO, false),
             mholder.numMessages(IMessage.ERROR, true),
             mholder.numMessages(IMessage.WARNING, false)


### PR DESCRIPTION
Solving https://github.com/jcabi/jcabi-maven-plugin/issues/40
Added cleanup of temp directory.