### PR TITLE
Added back the old logic for classpath elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,17 @@
             <artifactId>jcabi-maven-slf4j</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-dependency-tree</artifactId>
+            <version>2.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
@@ -115,6 +126,18 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>${maven.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>1.5.5</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.collections</groupId>
+                    <artifactId>google-collections</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.sonatype.sisu</groupId>

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -35,6 +35,7 @@ import com.jcabi.aspects.Loggable;
 import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -47,7 +48,10 @@ import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
+import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -56,10 +60,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.aspectj.bridge.IMessage;
 import org.aspectj.bridge.IMessageHolder;
 import org.aspectj.tools.ajc.Main;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.context.Context;
+import org.codehaus.plexus.context.ContextException;
+import org.codehaus.plexus.personality.plexus.lifecycle.phase.Contextualizable;
 import org.slf4j.impl.StaticLoggerBinder;
+import org.sonatype.aether.util.artifact.JavaScopes;
 
 /**
  * AspectJ compile CLASS files.
@@ -76,12 +90,12 @@ import org.slf4j.impl.StaticLoggerBinder;
     requiresDependencyResolution = ResolutionScope.COMPILE
 )
 @ToString
-@EqualsAndHashCode(callSuper = false, of = { "project" })
+@EqualsAndHashCode(callSuper = false, of = { "project", "scopes" })
 @Loggable(Loggable.DEBUG)
 @SuppressWarnings({
     "PMD.TooManyMethods", "PMD.ExcessiveImports", "PMD.GodClass"
 })
-public final class AjcMojo extends AbstractMojo {
+public final class AjcMojo extends AbstractMojo implements Contextualizable {
 
     /**
      * Classpath separator.
@@ -93,6 +107,12 @@ public final class AjcMojo extends AbstractMojo {
      */
     @Component
     private transient MavenProject project;
+
+    /**
+     * Maven session.
+     */
+    @Component
+    private transient MavenSession session;
 
     /**
      * Compiled directory.
@@ -149,6 +169,20 @@ public final class AjcMojo extends AbstractMojo {
     private transient File tempDirectory;
 
     /**
+     * Scopes to take into account.
+     */
+    @Parameter(
+        required = false,
+        readonly = false
+    )
+    private transient String[] scopes;
+
+    /**
+     * Container.
+     */
+    private transient PlexusContainer container;
+
+    /**
      * Java source version.
      */
     @Parameter(
@@ -191,6 +225,12 @@ public final class AjcMojo extends AbstractMojo {
         defaultValue = "${project.build.directory}/jcabi-ajc.log"
     )
     private transient String log;
+
+    @Override
+    public void contextualize(final Context context) throws ContextException {
+        this.container = (PlexusContainer) context
+            .get(PlexusConstants.PLEXUS_KEY);
+    }
 
     @Override
     @Loggable(value = Loggable.DEBUG, limit = 1, unit = TimeUnit.MINUTES)
@@ -306,7 +346,106 @@ public final class AjcMojo extends AbstractMojo {
         trim = false
     )
     private Collection<String> classpath() {
-        return this.classpathElements;
+        final Collection<String> scps;
+        if (this.scopes == null) {
+            scps = this.scope();
+        } else {
+            scps = Arrays.asList(this.scopes);
+        }
+        final Collection<String> elements = new LinkedList<String>();
+        try {
+            final DependencyGraphBuilder builder =
+                DependencyGraphBuilder.class.cast(
+                    this.container.lookup(
+                        DependencyGraphBuilder.class.getCanonicalName(),
+                        "default"
+                    )
+                );
+            final DependencyNode node = builder.buildDependencyGraph(
+                this.project,
+                new ArtifactFilter() {
+                    @Override
+                    public boolean include(final Artifact artifact) {
+                        return scps.contains(artifact.getScope());
+                    }
+                }
+            );
+            elements.addAll(this.dependencies(node, scps));
+        } catch (final DependencyGraphBuilderException ex) {
+            throw new IllegalStateException(ex);
+        } catch (final ComponentLookupException ex) {
+            throw new IllegalStateException(ex);
+        }
+        elements.addAll(this.classpathElements);
+        return elements;
+    }
+
+    /**
+     * Retrieve dependencies for from given node and scope.
+     * @param node Node to traverse.
+     * @param scps Scopes to use.
+     * @return Collection of dependency files.
+     */
+    private Collection<String> dependencies(final DependencyNode node,
+        final Collection<String> scps) {
+        final Artifact artifact = node.getArtifact();
+        final Collection<String> files = new LinkedList<String>();
+        if (artifact.getScope() == null
+            || scps.contains(artifact.getScope())) {
+            if (artifact.getScope() == null) {
+                files.add(artifact.getFile().toString());
+            } else {
+                files.add(
+                    this.session.getLocalRepository().find(artifact).getFile()
+                        .toString()
+                );
+            }
+            for (final DependencyNode child : node.getChildren()) {
+                if (child.getArtifact().compareTo(node.getArtifact()) != 0) {
+                    files.addAll(this.dependencies(child, scps));
+                }
+            }
+        }
+        return files;
+    }
+
+    /**
+     * Default scopes.
+     * @return List of scopes.
+     */
+    private Collection<String> scope() {
+        final List<String> scps;
+        if (this.eclipseAether()) {
+            scps = Arrays.asList(
+                org.eclipse.aether.util.artifact.JavaScopes.COMPILE,
+                org.eclipse.aether.util.artifact.JavaScopes.PROVIDED,
+                org.eclipse.aether.util.artifact.JavaScopes.RUNTIME,
+                org.eclipse.aether.util.artifact.JavaScopes.SYSTEM
+            );
+        } else {
+            scps = Arrays.asList(
+                JavaScopes.COMPILE,
+                JavaScopes.RUNTIME,
+                JavaScopes.PROVIDED,
+                JavaScopes.SYSTEM
+            );
+        }
+        return scps;
+    }
+
+    /**
+     * If environment is inside Eclipse Aether.
+     * @return True if Eclipse Aether.
+     */
+    private boolean eclipseAether() {
+        boolean found = false;
+        try {
+            Thread.currentThread().getContextClassLoader()
+                .loadClass("org.sonatype.aether.graph.DependencyFilter");
+        } catch (final ClassNotFoundException ex) {
+            found = true;
+        }
+        return found;
     }
 
     /**


### PR DESCRIPTION
This is for issue #48 .
Changes in commit 44117383ff8ff8aa19e8833644c5ef902e8ef40d fixed issue #41 , however they broke the classpath elements look-up logic. With those changes, only the elements in the **compile** classpath are searched. (E.g. the example project (findbugs-annotations) didn't work because jar **aspectjrt** was **runtime** scoped. It worked fine when I made the jar **compile** scoped)

**Fix** Let the changes from commit 44117383ff8ff8aa19e8833644c5ef902e8ef40d and also added back the old lookup logic (now they are combined, method ``classpath()`` returns both the artifacts found by our logic and those found by ``${project.compileClasspathElements}``.
Also, ``classpath()`` method now returns a collection of String filepaths, instead of Files, it's a bit lighter.

I tested and now it works for both the example projects (1 attached in issue #48 - findbugs-annotations and 1 attached in issue #41). 
