### PR TITLE
unwoven test classes are now copied under unwovenClassesDir + -test

### DIFF
--- a/src/it/ajc_noclasses/verify.groovy
+++ b/src/it/ajc_noclasses/verify.groovy
@@ -34,4 +34,4 @@
 */
 
 assert new File(basedir, 'target/classes').list().length == 0
-assert !new File(basedir, 'target/unwoven').list().exists()
+assert !new File(basedir, 'target/unwoven').exists()

--- a/src/it/ajc_noclasses/verify.groovy
+++ b/src/it/ajc_noclasses/verify.groovy
@@ -34,4 +34,4 @@
 */
 
 assert new File(basedir, 'target/classes').list().length == 0
-assert new File(basedir, 'target/unwoven').list() == null
+assert !new File(basedir, 'target/unwoven').list().exists()

--- a/src/it/ajc_noclasses/verify.groovy
+++ b/src/it/ajc_noclasses/verify.groovy
@@ -34,4 +34,4 @@
 */
 
 assert new File(basedir, 'target/classes').list().length == 0
-assert new File(basedir, 'target/unwoven').list().length == 0
+assert new File(basedir, 'target/unwoven').list() == null

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -544,7 +544,7 @@ public final class AjcMojo extends AbstractMojo implements Contextualizable {
     private void copyUnwovenClasses()
         throws MojoFailureException {
         if (this.hasClasses()) {
-            new CopyUnwovenClasses(
+            new UnwovenClasses(
                 this.unwovenClassesDir,
                 this.classesDirectory,
                 this.execution.getLifecyclePhase()

--- a/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
+++ b/src/main/java/com/jcabi/maven/plugin/AjcMojo.java
@@ -544,37 +544,11 @@ public final class AjcMojo extends AbstractMojo implements Contextualizable {
     private void copyUnwovenClasses()
         throws MojoFailureException {
         if (this.hasClasses()) {
-            final String phase = this.execution.getLifecyclePhase();
-            if ("process-classes".equals(phase)) {
-                this.unwovenClassesDir.mkdirs();
-                Logger.info(
-                    this, "Unwoven classes will be copied to %s",
-                    this.unwovenClassesDir
-                );
-            } else if ("process-test-classes".equals(phase)) {
-                final String testsuf = "-test";
-                final StringBuilder fpb = new StringBuilder();
-                fpb.append(this.unwovenClassesDir.getPath()).append(testsuf);
-                this.unwovenClassesDir = new File(fpb.toString());
-                this.unwovenClassesDir.mkdirs();
-                Logger.info(
-                    this, "Unwoven test classes will be copied to %s",
-                    this.unwovenClassesDir
-                );
-            } else {
-                return;
-            }
-            try {
-                this.copyClasses(this.unwovenClassesDir);
-            } catch (final IOException ex) {
-                throw new MojoFailureException(
-                    String.format(
-                        "Exception when copying unwoven classes to %s: %s",
-                        this.unwovenClassesDir, ex.getMessage()
-                    ),
-                    ex
-                );
-            }
+            new CopyUnwovenClasses(
+                this.unwovenClassesDir,
+                this.classesDirectory,
+                this.execution.getLifecyclePhase()
+            ).copy();
         } else {
             Logger.warn(
                 this,
@@ -583,15 +557,6 @@ public final class AjcMojo extends AbstractMojo implements Contextualizable {
                 this.unwovenClassesDir
             );
         }
-    }
-    /**
-     * Copies classes into a separate directory.
-     * @param dir The target directory
-     * @throws IOException If something goes wrong while copying a file
-     */
-    private void copyClasses(final File dir) throws IOException {
-        FileUtils.cleanDirectory(dir);
-        FileUtils.copyDirectory(this.classesDirectory, dir, false);
     }
 
     /**

--- a/src/main/java/com/jcabi/maven/plugin/CopyUnwovenClasses.java
+++ b/src/main/java/com/jcabi/maven/plugin/CopyUnwovenClasses.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.jcabi.maven.plugin;
+
+import com.jcabi.log.Logger;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugin.MojoFailureException;
+
+/**
+ * Unwoven classes should be copied to a specified directory.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @todo #48:30min This class extracts the copying of unwoven classes
+ *  from AjcMojo. Unit tests should be written for it.
+ */
+public final class CopyUnwovenClasses {
+    /**
+     * Directory where unwoven classes are saved.
+     */
+    private final transient File unwovenclassesdir;
+
+    /**
+     * Output directory from where the classes are taken.
+     */
+    private final transient File classesdir;
+
+    /**
+     * Maven execution phase.
+     */
+    private final transient String phase;
+    /**
+     * Constructor.
+     * @param unwoven Dir where unwoven classes go
+     * @param classes Directory where the classes are found
+     * @param execphase Maven execution phase
+     */
+    public CopyUnwovenClasses(
+        final File unwoven,
+        final File classes,
+        final String execphase
+    ) {
+        this.unwovenclassesdir = unwoven;
+        this.classesdir = classes;
+        this.phase = execphase;
+    }
+
+    /**
+     * Perform the copy.
+     * @throws MojoFailureException If there is an IOException when
+     *  copying the files
+     */
+    public void copy() throws MojoFailureException {
+        if ("process-classes".equals(this.phase)) {
+            this.unwovenclassesdir.mkdirs();
+            Logger.info(
+                this, "Unwoven classes will be copied to %s",
+                this.unwovenclassesdir
+            );
+            this.copyContents(this.classesdir, this.unwovenclassesdir);
+        } else if ("process-test-classes".equals(this.phase)) {
+            final String suffix = "-test";
+            final File unwovenTests = new File(
+                this.unwovenclassesdir.getPath().concat(suffix)
+            );
+            unwovenTests.mkdirs();
+            Logger.info(
+                this, "Unwoven test classes will be copied to %s",
+                unwovenTests
+            );
+            this.copyContents(this.classesdir, unwovenTests);
+        }
+    }
+
+    /**
+     * Copies contents from one dir to another.
+     * @param fromdir From directory
+     * @param todir To directory
+     * @throws MojoFailureException If something goes wrong while copying files
+     */
+    private void copyContents(
+        final File fromdir,
+        final File todir
+    ) throws MojoFailureException {
+        try {
+            FileUtils.cleanDirectory(this.unwovenclassesdir);
+            FileUtils.copyDirectory(fromdir, todir, false);
+        } catch (final IOException ex) {
+            throw new MojoFailureException(
+                String.format(
+                    "Exception when copying unwoven classes to %s: %s",
+                    this.unwovenclassesdir, ex.getMessage()
+                ),
+                ex
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
+++ b/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
@@ -45,6 +45,7 @@ import org.apache.maven.plugin.MojoFailureException;
  * @since 0.15
  */
 public final class UnwovenClasses {
+
     /**
      * Directory where unwoven classes are saved.
      */
@@ -105,7 +106,8 @@ public final class UnwovenClasses {
      * Copies contents from one dir to another.
      * @param from From directory
      * @param dest Destination directory
-     * @throws MojoFailureException If something goes wrong while copying files
+     * @throws MojoFailureException If something goes wrong while
+     *  cleaning the destination director or copying files to it
      */
     private void copyContents(
         final File from, final File dest) throws MojoFailureException {
@@ -113,7 +115,13 @@ public final class UnwovenClasses {
             FileUtils.cleanDirectory(dest);
             FileUtils.copyDirectory(from, dest, false);
         } catch (final IOException ex) {
-            throw new MojoFailureException(ex.getMessage(), ex);
+            final StringBuilder msg = new StringBuilder();
+            msg.append("Exception when cleaning destination directory ");
+            msg.append(" or when copying files to it: %s");
+            throw new MojoFailureException(
+                String.format(msg.toString(), ex.getMessage()),
+                ex
+            );
         }
     }
 

--- a/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
+++ b/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
@@ -35,43 +35,41 @@ import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 
 /**
- * Unwoven classes should be copied to a specified directory.
+ * Operations on the unwoven classes.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @todo #48:30min This class extracts the copying of unwoven classes
- *  from AjcMojo. Unit tests should be written for it.
+ *
  */
-public final class CopyUnwovenClasses {
+public final class UnwovenClasses {
     /**
      * Directory where unwoven classes are saved.
      */
-    private final transient File unwovenclassesdir;
+    private final transient File unwoven;
 
     /**
      * Output directory from where the classes are taken.
      */
-    private final transient File classesdir;
+    private final transient File classes;
 
     /**
      * Maven execution phase.
      */
     private final transient String phase;
+
     /**
      * Constructor.
-     * @param unwoven Dir where unwoven classes go
-     * @param classes Directory where the classes are found
-     * @param execphase Maven execution phase
+     * @param uvn Dir where unwoven classes go
+     * @param cls Directory where the classes are found
+     * @param mph Maven execution phase
      */
-    public CopyUnwovenClasses(
-        final File unwoven,
-        final File classes,
-        final String execphase
-    ) {
-        this.unwovenclassesdir = unwoven;
-        this.classesdir = classes;
-        this.phase = execphase;
+    public UnwovenClasses(final File uvn, final File cls,
+        final String mph) {
+        this.unwoven = uvn;
+        this.classes = cls;
+        this.phase = mph;
     }
 
     /**
@@ -80,45 +78,46 @@ public final class CopyUnwovenClasses {
      *  copying the files
      */
     public void copy() throws MojoFailureException {
-        if ("process-classes".equals(this.phase)) {
-            this.unwovenclassesdir.mkdirs();
+        if (LifecyclePhase.PROCESS_CLASSES.id().equals(this.phase)) {
+            this.unwoven.mkdirs();
             Logger.info(
                 this, "Unwoven classes will be copied to %s",
-                this.unwovenclassesdir
+                this.unwoven
             );
-            this.copyContents(this.classesdir, this.unwovenclassesdir);
-        } else if ("process-test-classes".equals(this.phase)) {
+            this.copyContents(this.classes, this.unwoven);
+        } else if (
+            LifecyclePhase.PROCESS_TEST_CLASSES.id().equals(this.phase)
+        ) {
             final String suffix = "-test";
             final File unwovenTests = new File(
-                this.unwovenclassesdir.getPath().concat(suffix)
+                this.unwoven.getPath().concat(suffix)
             );
             unwovenTests.mkdirs();
             Logger.info(
                 this, "Unwoven test classes will be copied to %s",
                 unwovenTests
             );
-            this.copyContents(this.classesdir, unwovenTests);
+            this.copyContents(this.classes, unwovenTests);
         }
     }
 
     /**
      * Copies contents from one dir to another.
-     * @param fromdir From directory
-     * @param todir To directory
+     * @param from From directory
+     * @param dest Destination directory
      * @throws MojoFailureException If something goes wrong while copying files
      */
     private void copyContents(
-        final File fromdir,
-        final File todir
-    ) throws MojoFailureException {
+        final File from,
+        final File dest) throws MojoFailureException {
         try {
-            FileUtils.cleanDirectory(this.unwovenclassesdir);
-            FileUtils.copyDirectory(fromdir, todir, false);
+            FileUtils.cleanDirectory(dest);
+            FileUtils.copyDirectory(from, dest, false);
         } catch (final IOException ex) {
             throw new MojoFailureException(
                 String.format(
                     "Exception when copying unwoven classes to %s: %s",
-                    this.unwovenclassesdir, ex.getMessage()
+                    this.unwoven, ex.getMessage()
                 ),
                 ex
             );

--- a/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
+++ b/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
@@ -37,10 +37,12 @@ import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoFailureException;
 
 /**
- * Operations on the unwoven classes.
+ * Operations on the unwoven classes, like storing them in a separate
+ * location from the woven ones. Unwoven classes are classes which weren't
+ * yet weaved by the aspect weaver.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- *
+ * @since 0.15
  */
 public final class UnwovenClasses {
     /**
@@ -60,19 +62,20 @@ public final class UnwovenClasses {
 
     /**
      * Constructor.
-     * @param uvn Dir where unwoven classes go
+     * @param uwvn Dir where unwoven classes go
      * @param cls Directory where the classes are found
-     * @param mph Maven execution phase
+     * @param phs Maven execution phase
      */
-    public UnwovenClasses(final File uvn, final File cls,
-        final String mph) {
-        this.unwoven = uvn;
+    public UnwovenClasses(final File uwvn, final File cls,
+        final String phs) {
+        this.unwoven = uwvn;
         this.classes = cls;
-        this.phase = mph;
+        this.phase = phs;
     }
 
     /**
-     * Perform the copy.
+     * Perform the copy. Unwoven classes go in <b>unwoven</b> directory, while
+     * unwoven test classes go in <b>unwoven</b> + -test directory.
      * @throws MojoFailureException If there is an IOException when
      *  copying the files
      */
@@ -105,19 +108,12 @@ public final class UnwovenClasses {
      * @throws MojoFailureException If something goes wrong while copying files
      */
     private void copyContents(
-        final File from,
-        final File dest) throws MojoFailureException {
+        final File from, final File dest) throws MojoFailureException {
         try {
             FileUtils.cleanDirectory(dest);
             FileUtils.copyDirectory(from, dest, false);
         } catch (final IOException ex) {
-            throw new MojoFailureException(
-                String.format(
-                    "Exception when copying unwoven classes to %s: %s",
-                    this.unwoven, ex.getMessage()
-                ),
-                ex
-            );
+            throw new MojoFailureException(ex.getMessage(), ex);
         }
     }
 

--- a/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
+++ b/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
@@ -35,7 +35,6 @@ import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 
 /**
  * Operations on the unwoven classes.
@@ -78,16 +77,14 @@ public final class UnwovenClasses {
      *  copying the files
      */
     public void copy() throws MojoFailureException {
-        if (LifecyclePhase.PROCESS_CLASSES.id().equals(this.phase)) {
+        if ("process-classes".equals(this.phase)) {
             this.unwoven.mkdirs();
             Logger.info(
                 this, "Unwoven classes will be copied to %s",
                 this.unwoven
             );
             this.copyContents(this.classes, this.unwoven);
-        } else if (
-            LifecyclePhase.PROCESS_TEST_CLASSES.id().equals(this.phase)
-        ) {
+        } else if ("process-test-classes".equals(this.phase)) {
             final String suffix = "-test";
             final File unwovenTests = new File(
                 this.unwoven.getPath().concat(suffix)

--- a/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
+++ b/src/main/java/com/jcabi/maven/plugin/UnwovenClasses.java
@@ -115,11 +115,11 @@ public final class UnwovenClasses {
             FileUtils.cleanDirectory(dest);
             FileUtils.copyDirectory(from, dest, false);
         } catch (final IOException ex) {
-            final StringBuilder msg = new StringBuilder();
-            msg.append("Exception when cleaning destination directory ");
-            msg.append(" or when copying files to it: %s");
             throw new MojoFailureException(
-                String.format(msg.toString(), ex.getMessage()),
+                String.format(
+                    "Error when cleaning dest dir or when copying files: %s",
+                    ex.getMessage()
+                ),
                 ex
             );
         }

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -33,6 +33,8 @@ import java.io.File;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -50,26 +52,38 @@ public final class UnwovenClassesTest {
     private static final String CLASSES = "src/test/resources/classes";
 
     /**
+     * Unwoven classes dir.
+     */
+    private static final String UNWOVEN = "src/test/resources/unwoven";
+
+    /**
+     * Clean also before just in case <b>AfterClass</b> failes.
+     */
+    @BeforeClass
+    public static void cleanBefore() {
+        FileUtils.deleteQuietly(new File("src/test/resources/unwoven-test"));
+        FileUtils.deleteQuietly(new File(UNWOVEN));
+    }
+
+    /**
      * UnwovenClasses can copy compiled classes to a destination directory.
      * @throws Exception If something goes wrong
      */
     @Test
     public void copiesUnwovenClasses() throws Exception {
-        final File unwoven = new File("src/test/resources/unwovendir");
         new UnwovenClasses(
-            unwoven,
+            new File(UNWOVEN),
             new File(CLASSES),
             "process-classes"
         ).copy();
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwovendir/MyPojo.txt").exists(),
+            new File("src/test/resources/unwoven/MyPojo.txt").exists(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwovendir/MySecondPojo.txt").exists(),
+            new File("src/test/resources/unwoven/MySecondPojo.txt").exists(),
             Matchers.is(true)
         );
-        FileUtils.deleteDirectory(unwoven);
     }
 
     /**
@@ -79,7 +93,7 @@ public final class UnwovenClassesTest {
     @Test
     public void copiesUnwovenTestClasses() throws Exception {
         new UnwovenClasses(
-            new File("src/test/resources/unwoven"),
+            new File(UNWOVEN),
             new File(CLASSES),
             "process-test-classes"
         ).copy();
@@ -93,6 +107,16 @@ public final class UnwovenClassesTest {
             ).exists(),
             Matchers.is(true)
         );
-        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
     }
+ 
+    /**
+     * Clean also before just in case <b>AfterClass</b> failes.
+     * @throws Exception If something goes wrong
+     */
+    @AfterClass
+    public static void cleanAfter() throws Exception {
+        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
+        FileUtils.deleteDirectory(new File(UNWOVEN));
+    }
+
 }

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -57,7 +57,7 @@ public final class UnwovenClassesTest {
     private static final String UNWOVEN = "src/test/resources/unwoven";
 
     /**
-     * Clean also before just in case <b>AfterClass</b> failes.
+     * Clean also before just in case <b>AfterClass</b> fails.
      */
     @BeforeClass
     public static void cleanBefore() {
@@ -110,7 +110,7 @@ public final class UnwovenClassesTest {
     }
  
     /**
-     * Clean also before just in case <b>AfterClass</b> failes.
+     * Clean resources after tests run.
      * @throws Exception If something goes wrong
      */
     @AfterClass

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -33,27 +33,16 @@ import java.io.File;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Test;
 
 /**
- * Unit tests for {@UnwovenClasses).
+ * Unit tests for {@link UnwovenClasses).
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
+ * @since 0.15
  * @checkstyle MultipleStringLiteralsCheck (150 lines)
- *
  */
 public final class UnwovenClassesTest {
-
-    /**
-     * Delete the created directories after each test.
-     * @throws Exception If something goes wrong.
-     */
-    @After
-    public void clean() throws Exception {
-        FileUtils.deleteDirectory(new File("src/test/resources/unwoven"));
-        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
-    }
 
     /**
      * UnwovenClasses can copy compiled classes to a destination directory.
@@ -61,34 +50,32 @@ public final class UnwovenClassesTest {
      */
     @Test
     public void copiesUnwovenClasses() throws Exception {
-        final File classes = new File("src/test/resources/classes");
-        final File unwoven = new File("src/test/resources/unwoven");
-        new UnwovenClasses(
+        final File unwoven = new File("src/test/resources/unwovendir");
+    	new UnwovenClasses(
             unwoven,
-            classes,
+            new File("src/test/resources/classes"),
             "process-classes"
         ).copy();
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwoven/MyPojo.txt").exists(),
+            new File("src/test/resources/unwovendir/MyPojo.txt").exists(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwoven/MySecondPojo.txt").exists(),
+            new File("src/test/resources/unwovendir/MySecondPojo.txt").exists(),
             Matchers.is(true)
         );
+        FileUtils.deleteDirectory(unwoven);
     }
 
     /**
      * UnwoveClasses can copy test classes to a destination directory.
-     * @throws Exception If something goes wrong.
+     * @throws Exception If something goes wrong
      */
     @Test
     public void copiesUnwovenTestClasses() throws Exception {
-        final File classes = new File("src/test/resources/classes");
-        final File unwoven = new File("src/test/resources/unwoven");
         new UnwovenClasses(
-            unwoven,
-            classes,
+            new File("src/test/resources/unwoven"),
+            new File("src/test/resources/classes"),
             "process-test-classes"
         ).copy();
         MatcherAssert.assertThat(
@@ -101,5 +88,6 @@ public final class UnwovenClassesTest {
             ).exists(),
             Matchers.is(true)
         );
+        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
     }
 }

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2012-2015, jcabi.com
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met: 1) Redistributions of source code must retain the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer. 2) Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided
+ * with the distribution. 3) Neither the name of the jcabi.com nor
+ * the names of its contributors may be used to endorse or promote
+ * products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+ * NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+ * FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ * THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.jcabi.maven.plugin;
+
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@UnwovenClasses).
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @checkstyle MultipleStringLiteralsCheck (150 lines)
+ *
+ */
+public final class UnwovenClassesTest {
+
+    /**
+     * Delete the created directories after each test.
+     * @throws Exception If something goes wrong.
+     */
+    @After
+    public void clean() throws Exception {
+        FileUtils.deleteDirectory(new File("src/test/resources/unwoven"));
+        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
+    }
+
+    /**
+     * UnwovenClasses can copy compiled classes to a destination directory.
+     * @throws Exception If something goes wrong
+     */
+    @Test
+    public void copiesUnwovenClasses() throws Exception {
+        final File classes = new File("src/test/resources/classes");
+        final File unwoven = new File("src/test/resources/unwoven");
+        new UnwovenClasses(
+            unwoven,
+            classes,
+            LifecyclePhase.PROCESS_CLASSES.id()
+        ).copy();
+        MatcherAssert.assertThat(
+            new File("src/test/resources/unwoven/MyPojo.class").exists(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new File("src/test/resources/unwoven/MySecondPojo.class").exists(),
+            Matchers.is(true)
+        );
+    }
+
+    /**
+     * UnwoveClasses can copy test classes to a destination directory.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void copiesUnwovenTestClasses() throws Exception {
+        final File classes = new File("src/test/resources/classes");
+        final File unwoven = new File("src/test/resources/unwoven");
+        new UnwovenClasses(
+            unwoven,
+            classes,
+            LifecyclePhase.PROCESS_TEST_CLASSES.id()
+        ).copy();
+        MatcherAssert.assertThat(
+            new File("src/test/resources/unwoven-test/MyPojo.class").exists(),
+            Matchers.is(true)
+        );
+        MatcherAssert.assertThat(
+            new File(
+                "src/test/resources/unwoven-test/MySecondPojo.class"
+            ).exists(),
+            Matchers.is(true)
+        );
+    }
+}

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -103,10 +103,6 @@ public final class UnwovenClassesTest {
             Matchers.is(true)
         );
     }
-    @Test
-    public void test() throws Exception {
-    	FileUtils.deleteDirectory(new File("src/test/resources/test"));
-    }
 
     /**
      * Clean resources after tests run.

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -119,6 +119,6 @@ public final class UnwovenClassesTest {
      */
     public static void deleteResourceDirs() throws Exception {
         FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
-        FileUtils.deleteDirectory(new File(UNWOVEN));    
+        FileUtils.deleteDirectory(new File(UNWOVEN));
     }
 }

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.15
- * @checkstyle MultipleStringLiteralsCheck (150 lines)
  */
 public final class UnwovenClassesTest {
 
@@ -58,11 +57,11 @@ public final class UnwovenClassesTest {
 
     /**
      * Clean also before just in case <b>AfterClass</b> fails.
+     * @throws Exception If something goes wrong
      */
     @BeforeClass
-    public static void cleanBefore() {
-        FileUtils.deleteQuietly(new File("src/test/resources/unwoven-test"));
-        FileUtils.deleteQuietly(new File(UNWOVEN));
+    public static void cleanBefore() throws Exception {
+        deleteResourceDirs();
     }
 
     /**
@@ -72,9 +71,7 @@ public final class UnwovenClassesTest {
     @Test
     public void copiesUnwovenClasses() throws Exception {
         new UnwovenClasses(
-            new File(UNWOVEN),
-            new File(CLASSES),
-            "process-classes"
+            new File(UNWOVEN), new File(CLASSES), "process-classes"
         ).copy();
         MatcherAssert.assertThat(
             new File("src/test/resources/unwoven/MyPojo.txt").exists(),
@@ -87,15 +84,13 @@ public final class UnwovenClassesTest {
     }
 
     /**
-     * UnwoveClasses can copy test classes to a destination directory.
+     * UnwovenClasses can copy test classes to a destination directory.
      * @throws Exception If something goes wrong
      */
     @Test
     public void copiesUnwovenTestClasses() throws Exception {
         new UnwovenClasses(
-            new File(UNWOVEN),
-            new File(CLASSES),
-            "process-test-classes"
+            new File(UNWOVEN), new File(CLASSES), "process-test-classes"
         ).copy();
         MatcherAssert.assertThat(
             new File("src/test/resources/unwoven-test/MyPojo.txt").exists(),
@@ -108,6 +103,10 @@ public final class UnwovenClassesTest {
             Matchers.is(true)
         );
     }
+    @Test
+    public void test() throws Exception {
+    	FileUtils.deleteDirectory(new File("src/test/resources/test"));
+    }
 
     /**
      * Clean resources after tests run.
@@ -115,8 +114,15 @@ public final class UnwovenClassesTest {
      */
     @AfterClass
     public static void cleanAfter() throws Exception {
-        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
-        FileUtils.deleteDirectory(new File(UNWOVEN));
+        deleteResourceDirs();
     }
 
+    /**
+     * Delete test resource directories (for cleanup).
+     * @throws Exception If something goes wrong
+     */
+    public static void deleteResourceDirs() throws Exception {
+        FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
+        FileUtils.deleteDirectory(new File(UNWOVEN));    
+    }
 }

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -108,7 +108,7 @@ public final class UnwovenClassesTest {
             Matchers.is(true)
         );
     }
- 
+
     /**
      * Clean resources after tests run.
      * @throws Exception If something goes wrong

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -60,7 +60,7 @@ public final class UnwovenClassesTest {
      * @throws Exception If something goes wrong
      */
     @BeforeClass
-    private static void cleanBefore() throws Exception {
+    public static void cleanBefore() throws Exception {
         deleteResourceDirs();
     }
 
@@ -109,7 +109,7 @@ public final class UnwovenClassesTest {
      * @throws Exception If something goes wrong
      */
     @AfterClass
-    private static void cleanAfter() throws Exception {
+    public static void cleanAfter() throws Exception {
         deleteResourceDirs();
     }
 

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -56,7 +56,7 @@ public final class UnwovenClassesTest {
     @Test
     public void copiesUnwovenClasses() throws Exception {
         final File unwoven = new File("src/test/resources/unwovendir");
-    	new UnwovenClasses(
+        new UnwovenClasses(
             unwoven,
             new File(CLASSES),
             "process-classes"

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -31,7 +31,6 @@ package com.jcabi.maven.plugin;
 
 import java.io.File;
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -67,7 +66,7 @@ public final class UnwovenClassesTest {
         new UnwovenClasses(
             unwoven,
             classes,
-            LifecyclePhase.PROCESS_CLASSES.id()
+            "process-classes"
         ).copy();
         MatcherAssert.assertThat(
             new File("src/test/resources/unwoven/MyPojo.txt").exists(),
@@ -90,7 +89,7 @@ public final class UnwovenClassesTest {
         new UnwovenClasses(
             unwoven,
             classes,
-            LifecyclePhase.PROCESS_TEST_CLASSES.id()
+            "process-test-classes"
         ).copy();
         MatcherAssert.assertThat(
             new File("src/test/resources/unwoven-test/MyPojo.txt").exists(),

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -45,6 +45,11 @@ import org.junit.Test;
 public final class UnwovenClassesTest {
 
     /**
+     * Classes directory.
+     */
+    private static final String CLASSES = "src/test/resources/classes";
+
+    /**
      * UnwovenClasses can copy compiled classes to a destination directory.
      * @throws Exception If something goes wrong
      */
@@ -53,7 +58,7 @@ public final class UnwovenClassesTest {
         final File unwoven = new File("src/test/resources/unwovendir");
     	new UnwovenClasses(
             unwoven,
-            new File("src/test/resources/classes"),
+            new File(CLASSES),
             "process-classes"
         ).copy();
         MatcherAssert.assertThat(
@@ -75,7 +80,7 @@ public final class UnwovenClassesTest {
     public void copiesUnwovenTestClasses() throws Exception {
         new UnwovenClasses(
             new File("src/test/resources/unwoven"),
-            new File("src/test/resources/classes"),
+            new File(CLASSES),
             "process-test-classes"
         ).copy();
         MatcherAssert.assertThat(

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -60,7 +60,7 @@ public final class UnwovenClassesTest {
      * @throws Exception If something goes wrong
      */
     @BeforeClass
-    public static void cleanBefore() throws Exception {
+    private static void cleanBefore() throws Exception {
         deleteResourceDirs();
     }
 
@@ -109,7 +109,7 @@ public final class UnwovenClassesTest {
      * @throws Exception If something goes wrong
      */
     @AfterClass
-    public static void cleanAfter() throws Exception {
+    private static void cleanAfter() throws Exception {
         deleteResourceDirs();
     }
 
@@ -117,7 +117,7 @@ public final class UnwovenClassesTest {
      * Delete test resource directories (for cleanup).
      * @throws Exception If something goes wrong
      */
-    public static void deleteResourceDirs() throws Exception {
+    private static void deleteResourceDirs() throws Exception {
         FileUtils.deleteDirectory(new File("src/test/resources/unwoven-test"));
         FileUtils.deleteDirectory(new File(UNWOVEN));
     }

--- a/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
+++ b/src/test/java/com/jcabi/maven/plugin/UnwovenClassesTest.java
@@ -70,11 +70,11 @@ public final class UnwovenClassesTest {
             LifecyclePhase.PROCESS_CLASSES.id()
         ).copy();
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwoven/MyPojo.class").exists(),
+            new File("src/test/resources/unwoven/MyPojo.txt").exists(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwoven/MySecondPojo.class").exists(),
+            new File("src/test/resources/unwoven/MySecondPojo.txt").exists(),
             Matchers.is(true)
         );
     }
@@ -93,12 +93,12 @@ public final class UnwovenClassesTest {
             LifecyclePhase.PROCESS_TEST_CLASSES.id()
         ).copy();
         MatcherAssert.assertThat(
-            new File("src/test/resources/unwoven-test/MyPojo.class").exists(),
+            new File("src/test/resources/unwoven-test/MyPojo.txt").exists(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
             new File(
-                "src/test/resources/unwoven-test/MySecondPojo.class"
+                "src/test/resources/unwoven-test/MySecondPojo.txt"
             ).exists(),
             Matchers.is(true)
         );

--- a/src/test/resources/classes/MyPojo.txt
+++ b/src/test/resources/classes/MyPojo.txt
@@ -1,0 +1,1 @@
+txt file instead of .class because git ignores .class files (shouldn't matter for the test, anyway)

--- a/src/test/resources/classes/MySecondPojo.txt
+++ b/src/test/resources/classes/MySecondPojo.txt
@@ -1,0 +1,1 @@
+txt file instead of .class because git ignores .class files (shouldn't matter for the test, anyway)


### PR DESCRIPTION
PR for #48 . Fixed bug (unwoven test classes would override the unwoven classes). Also, extracted xopying ligic into ``UnwovenClasses`` + unit tests