### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://travis-ci.org/jcabi/jcabi-maven-plugin.svg?branch=master)](https://travis-ci.org/jcabi/jcabi-maven-plugin)
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-maven-plugin)](http://www.0pdd.com/p?name=jcabi/jcabi-maven-plugin)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-maven-plugin)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-maven-plugin/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-maven-plugin)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-maven-plugin.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-maven-plugin)
 
 More details are here: [plugin.jcabi.com](http://plugin.jcabi.com/index.html)
 


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io

Signed-off-by: Valeriy.Vyrva <valery1707@gmail.com>